### PR TITLE
Update values.yaml

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -26,6 +26,15 @@ groups:
         softwareVersion: "1.7.0-ppc_docker"
       PanelPC-GUI:
         softwareVersion: "2.3.0-server"
+  production-vdberge:
+    software:
+      QG:
+        softwareVersion: "1.7.0-pc_min-speed-limited-orin"
+        jetsonType: "orin"
+      PanelPC-API:
+        softwareVersion: "1.7.0-ppc_docker"
+      PanelPC-GUI:
+        softwareVersion: "2.3.0-server"
   divider:
     software:
       DV:


### PR DESCRIPTION
To enable a seperate image to run on vdberge we need to make a new group with the docker image for quality grader pointing to a different version built especially for this client