### PR TITLE
Add vs-flipper-test group to production cluster in values.yaml

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -31,3 +31,11 @@ groups:
         softwareVersion: "dev_1.7.0ppc_multi-model"
       PanelPC-GUI:
         softwareVersion: "dev_2.4.0-server"
+  vs-flipper-test:
+    software:
+      QG:
+        softwareVersion: "dev_vs_flipper_tests-orin"
+      PanelPC-API:
+        softwareVersion: "v1.7.7-api"
+      PanelPC-GUI:
+        softwareVersion: "2.3.0-server"


### PR DESCRIPTION
- Required to perform test at client with new flipper test
- dev_vs_flipper_tests-orin image based on version 1.7.7-pc, with a small adjustment to code. settings.ini containers version 1.7.7-pc, but noo migration needed, so assuming this will not cause issues.