### PR TITLE
Add v179 group for production testing

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -39,3 +39,11 @@ groups:
         softwareVersion: "v1.7.7-api"
       PanelPC-GUI:
         softwareVersion: "2.3.0-server"
+  v179:
+    software:
+      QG:
+        softwareVersion: "v1.7.9-pc-orin"
+      PanelPC-API:
+        softwareVersion: "v1.7.7-api"
+      PanelPC-GUI:
+        softwareVersion: "2.3.0-server"


### PR DESCRIPTION
Add the v179 group, a copy of production, with QG softwareVersion 'v1.7.9-pc-orin'. This version can then quickly be tested on a production machine, and soon released to all machines.