### PR TITLE
Release QG version 1.7.9-pc

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -2,7 +2,7 @@ groups:
   production:
     software:
       QG:
-        softwareVersion: "v1.7.8-pc-orin"
+        softwareVersion: "v1.7.9-pc-orin"
       PanelPC-API:
         softwareVersion: "v1.7.7-api"
       PanelPC-GUI:
@@ -35,14 +35,6 @@ groups:
     software:
       QG:
         softwareVersion: "dev_vs_flipper_tests-orin"
-      PanelPC-API:
-        softwareVersion: "v1.7.7-api"
-      PanelPC-GUI:
-        softwareVersion: "2.3.0-server"
-  v179:
-    software:
-      QG:
-        softwareVersion: "v1.7.9-pc-orin"
       PanelPC-API:
         softwareVersion: "v1.7.7-api"
       PanelPC-GUI:


### PR DESCRIPTION
Releases QG software version 1.7.9-pc to the production group. 

[MD-924](https://flikweertvision.atlassian.net/browse/MD-924).