### PR TITLE
Update production-plc-group to 1.8.1

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -14,11 +14,11 @@ groups:
   production_plc:
     software:
       QG:
-        softwareVersion: "v1.7.9-pc-orin"
+        softwareVersion: "v1.8.1-pc-orin"
       PanelPC-API:
-        softwareVersion: "v1.7.7-api"
+        softwareVersion: "v1.8.1-api"
       PanelPC-GUI:
-        softwareVersion: "dev_2.3.0-server_calibration-tool-shortcut"
+        softwareVersion: "v2.4.1-server"
       Calibration-Tool:
         softwareVersion: "v0.2.51"
       Plc-Tool:


### PR DESCRIPTION
Update the 'production-plc' group, used for testing the plc update tool, from 1.7.9 to 1.8.1. 
This way the group is up to date with the production group.