### PR TITLE
Update production_plc and add added-sensors-test group

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -14,11 +14,11 @@ groups:
   production_plc:
     software:
       QG:
-        softwareVersion: "v1.7.9-pc-orin"
+        softwareVersion: "v1.8.1-pc-orin"
       PanelPC-API:
-        softwareVersion: "v1.7.7-api"
+        softwareVersion: "v1.8.1-api"
       PanelPC-GUI:
-        softwareVersion: "dev_2.3.0-server_calibration-tool-shortcut"
+        softwareVersion: "v2.4.1-server"
       Calibration-Tool:
         softwareVersion: "v0.2.51"
       Plc-Tool:
@@ -107,3 +107,15 @@ groups:
         softwareVersion: "v0.2.51"
       Plc-Tool:
         softwareVersion: "empty"
+  added-sensors-test:
+    software:
+      QG:
+        softwareVersion: "dev_MD-315_added-sensors-with-status-33-orin"
+      PanelPC-API:
+        softwareVersion: "dev_add-error-33"
+      PanelPC-GUI:
+        softwareVersion: "v2.4.1-server"
+      Calibration-Tool:
+        softwareVersion: "v0.2.51"
+      Plc-Tool:
+        softwareVersion: "QG_V2.4.7_SP18"


### PR DESCRIPTION
- Update the production_plc group to 1.8.1 to match the production group.
- Add the added-sensors-test group to test a new feature and plc version at clients.