### PR TITLE
Add 'added-sensors-agroduiv-test' group.

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -119,3 +119,15 @@ groups:
         softwareVersion: "v0.2.51"
       Plc-Tool:
         softwareVersion: "QG_V2.4.7_SP18"
+  added-sensors-agroduiv-test:
+    software:
+      QG:
+        softwareVersion: "dev_MD-315_added-sensors-with-status-33-orin"
+      PanelPC-API:
+        softwareVersion: "dev_add-error-33"
+      PanelPC-GUI:
+        softwareVersion: "v2.4.1-server"
+      Calibration-Tool:
+        softwareVersion: "v0.2.51"
+      Plc-Tool:
+        softwareVersion: "empty"


### PR DESCRIPTION
Adds `added-sensors-agroduiv-test` group.
- Copy of existing `added-sensors-test` group, but with "empty" plc version.
- Required to test added sensors update at Agro Duiveland without automatically updating the plc.