### PR TITLE
Upgrade Telemetry-Producer to v0.0.26

### DIFF
--- a/charts/qg/templates/telemetry_producer.yaml
+++ b/charts/qg/templates/telemetry_producer.yaml
@@ -34,18 +34,21 @@ spec:
 
       hostNetwork: true  # Equivalent to --net=host
 
-      nodeSelector:
-        machine-type: QG
-
       containers:
       - name: telemetry-producer
         image: docker.io/flikweertvision/fv-producer:{{ $software.softwareVersion }}
         imagePullPolicy: IfNotPresent
         env:
-        - name: NODE_NAME
+        - name: MACHINE_IP
           valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
+            fieldRef:
+              fieldPath: status.podIP
+        - name: BACKUPCOLLECTOR_INTERVAL_MINS
+          value: "1"
+        - name: MACHINEDATACOLLECTOR_INTERVAL_MINS
+          value: "1"
+        - name: METERREADINGCOLLECTOR_INTERVAL_MINS
+          value: "1"
         volumeMounts:
         - name: quality-grader-home
           mountPath: /home

--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -2,7 +2,7 @@ groups:
   production:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -16,7 +16,7 @@ groups:
   production_plc:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "v1.8.2-pc-orin"
       PanelPC-API:
@@ -42,7 +42,7 @@ groups:
   multi-model:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "v1.8.2-pc-orin"
       PanelPC-API:
@@ -56,7 +56,7 @@ groups:
   vs-flipper-test:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "dev_vs_flipper_tests-orin"
       PanelPC-API:
@@ -70,7 +70,7 @@ groups:
   service-round-xavier-swap:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "v1.7.9-pc-orin"
       PanelPC-API:
@@ -84,7 +84,7 @@ groups:
   production-europe:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -98,7 +98,7 @@ groups:
   production-asian-oceania:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -112,7 +112,7 @@ groups:
   production-americas:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -126,7 +126,7 @@ groups:
   added-sensors-test:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "dev_MD-315_added-sensors-with-status-33-orin"
       PanelPC-API:
@@ -140,7 +140,7 @@ groups:
   added-sensors-agroduiv-test:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.21"
+        softwareVersion: "v0.0.26"
       QG:
         softwareVersion: "dev_MD-315_added-sensors-with-status-33-orin"
       PanelPC-API:


### PR DESCRIPTION
The following is changed:

- It reads meter readings and machine status from node and not from global machine IP
- It can run on PanelPC
- Backups on PanelPC should work since the entire home directory is mounted as readonly
- Added some envs to manually set the collector intervals for easier testing
- Added logging to see exactly what cron jobs are scheduled at what interval and when they run