### PR TITLE
add hotfix-calibration-service-round group and update calibration tool to hotfix version except the original service-round-xavier-swap

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -10,7 +10,7 @@ groups:
       PanelPC-GUI:
         softwareVersion: "v2.4.2-server"
       Calibration-Tool:
-        softwareVersion: "v0.2.71"
+        softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "empty"
   production_plc:
@@ -24,7 +24,7 @@ groups:
       PanelPC-GUI:
         softwareVersion: "v2.4.2-server"
       Calibration-Tool:
-        softwareVersion: "v0.2.71"
+        softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "QG_V2.4.6_SP18"
   divider:
@@ -81,6 +81,20 @@ groups:
         softwareVersion: "v0.2.71"
       Plc-Tool:
         softwareVersion: "empty"
+  hotfix-calibration-service-round:
+      software:
+      Telemetry-Producer:
+        softwareVersion: "v0.0.21"
+      QG:
+        softwareVersion: "v1.7.9-pc-orin"
+      PanelPC-API:
+        softwareVersion: "v1.7.7-api"
+      PanelPC-GUI:
+        softwareVersion: "dev_2.3.0-server_calibration-tool-shortcut"
+      Calibration-Tool:
+        softwareVersion: "v0.2.71.1-hotfix"
+      Plc-Tool:
+        softwareVersion: "empty"
   production-europe:
     software:
       Telemetry-Producer:
@@ -92,7 +106,7 @@ groups:
       PanelPC-GUI:
         softwareVersion: "v2.4.2-server"
       Calibration-Tool:
-        softwareVersion: "v0.2.71"
+        softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "empty"
   production-asian-oceania:
@@ -106,7 +120,7 @@ groups:
       PanelPC-GUI:
         softwareVersion: "v2.4.2-server"
       Calibration-Tool:
-        softwareVersion: "v0.2.71"
+        softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "empty"
   production-americas:
@@ -120,7 +134,7 @@ groups:
       PanelPC-GUI:
         softwareVersion: "v2.4.2-server"
       Calibration-Tool:
-        softwareVersion: "v0.2.71"
+        softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "empty"
   added-sensors-test:


### PR DESCRIPTION
usb sticks updated with the new calibration tool hotfix should use the "hotfix-calibration-service-round" group
usb sticks NOT updated with the new calibration tool hotfix AND slow internet should use the old "service-round-xavier-swap" group