### PR TITLE
Add test group for 'added sensors' testing on SRS and old QG

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -156,12 +156,26 @@ groups:
       Telemetry-Producer:
         softwareVersion: "v0.0.29"
       QG:
-        softwareVersion: "dev_MD-315_added-sensors-with-status-33-orin"
+        softwareVersion: "dev_MD-315_add-sensors-orin"
       PanelPC-API:
-        softwareVersion: "dev_add-error-33"
+        softwareVersion: "v1.8.2-api"
       PanelPC-GUI:
-        softwareVersion: "v2.4.1-server"
+        softwareVersion: "v2.4.2-server"
       Calibration-Tool:
         softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "QG_V2.4.7_SP18"
+  added-sensors-test-empty-plc:
+    software:
+      Telemetry-Producer:
+        softwareVersion: "v0.0.29"
+      QG:
+        softwareVersion: "dev_MD-315_add-sensors-orin"
+      PanelPC-API:
+        softwareVersion: "v1.8.2-api"
+      PanelPC-GUI:
+        softwareVersion: "v2.4.2-server"
+      Calibration-Tool:
+        softwareVersion: "v0.2.71.1-hotfix"
+      Plc-Tool:
+        softwareVersion: "empty"


### PR DESCRIPTION
- Update existing added-sensors-test group to latest dev and production code
- Create added-sensors-test-empty-plc group to test on Standalone RS' and old QG's. These should not automatically update their plc code

