### PR TITLE
Bump Telemetry-Producer to v0.0.30

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -2,7 +2,7 @@ groups:
   production:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -16,7 +16,7 @@ groups:
   production_plc:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -30,7 +30,7 @@ groups:
   production_plc_empty:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -56,7 +56,7 @@ groups:
   multi-model:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.8.2-pc-orin"
       PanelPC-API:
@@ -70,7 +70,7 @@ groups:
   vs-flipper-test:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "dev_vs_flipper_tests-orin"
       PanelPC-API:
@@ -84,7 +84,7 @@ groups:
   service-round-xavier-swap:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.7.9-pc-orin"
       PanelPC-API:
@@ -98,7 +98,7 @@ groups:
   hotfix-calibration-service-round:
       software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.7.9-pc-orin"
       PanelPC-API:
@@ -112,7 +112,7 @@ groups:
   production-europe:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -126,7 +126,7 @@ groups:
   production-asian-oceania:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -140,7 +140,7 @@ groups:
   production-americas:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "v1.8.3-pc-orin"
       PanelPC-API:
@@ -154,7 +154,7 @@ groups:
   added-sensors-test:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "dev_MD-315_add-sensors-orin"
       PanelPC-API:
@@ -168,7 +168,7 @@ groups:
   added-sensors-test-empty-plc:
     software:
       Telemetry-Producer:
-        softwareVersion: "v0.0.29"
+        softwareVersion: "v0.0.30"
       QG:
         softwareVersion: "dev_MD-315_add-sensors-orin"
       PanelPC-API:


### PR DESCRIPTION
Excludes big classification JSON files from backups.