### PR TITLE
MD-1090 Add plc update release groups

### DIFF
--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -13,7 +13,21 @@ groups:
         softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "QG_V2.4.6_SP18"
-  production-semi-manual-plc:
+  production-empty-plc:
+    software:
+      Telemetry-Producer:
+        softwareVersion: "v0.0.29"
+      QG:
+        softwareVersion: "v1.8.3-pc-orin"
+      PanelPC-API:
+        softwareVersion: "v1.8.2-api"
+      PanelPC-GUI:
+        softwareVersion: "v2.4.2-server"
+      Calibration-Tool:
+        softwareVersion: "v0.2.71.1-hotfix"
+      Plc-Tool:
+        softwareVersion: "empty"
+  qg-srs-update-transfer:
     software:
       Telemetry-Producer:
         softwareVersion: "v0.0.29"
@@ -27,7 +41,7 @@ groups:
         softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "QG_V2.4.6_SP18"
-  production-manual-plc:
+  qg-old-update-transfer:
     software:
       Telemetry-Producer:
         softwareVersion: "v0.0.29"

--- a/charts/qg/values.yaml
+++ b/charts/qg/values.yaml
@@ -13,6 +13,34 @@ groups:
         softwareVersion: "v0.2.71.1-hotfix"
       Plc-Tool:
         softwareVersion: "QG_V2.4.6_SP18"
+  production-semi-manual-plc:
+    software:
+      Telemetry-Producer:
+        softwareVersion: "v0.0.29"
+      QG:
+        softwareVersion: "v1.8.3-pc-orin"
+      PanelPC-API:
+        softwareVersion: "v1.8.2-api"
+      PanelPC-GUI:
+        softwareVersion: "v2.4.2-server"
+      Calibration-Tool:
+        softwareVersion: "v0.2.71.1-hotfix"
+      Plc-Tool:
+        softwareVersion: "QG_V2.4.6_SP18"
+  production-manual-plc:
+    software:
+      Telemetry-Producer:
+        softwareVersion: "v0.0.29"
+      QG:
+        softwareVersion: "v1.8.3-pc-orin"
+      PanelPC-API:
+        softwareVersion: "v1.8.2-api"
+      PanelPC-GUI:
+        softwareVersion: "v2.4.2-server"
+      Calibration-Tool:
+        softwareVersion: "v0.2.71.1-hotfix"
+      Plc-Tool:
+        softwareVersion: "empty"
   production_plc:
     software:
       Telemetry-Producer:


### PR DESCRIPTION
Adds 3 groups for the upcoming plc release to aid updating from the old 2.4.6 to the new 2.4.7.
- **production-empty-plc**: replaces production_plc_empty and will be used for old QG's running the new version after manually updating.
- **qg-srs-update-transfer**: will be used for clusters with SRS' still running the old version before updating manually. This group will be removed after the manual updates are done.
- **qg-old-update-transfer**: will be used for clusters with old QG's still running the old version before updating manually. This group will be removed after the manual updates are done.

**production-empty-plc** should be updated to the new versions (1.8.4 and 2.4.7) once those are released. **qg-srs-update-transfer** and **qg-old-update-transfer** should stay on the old versions (1.8.3 & 2.4.6)

More info: https://flikweertvision.atlassian.net/browse/MD-1090